### PR TITLE
"ref" support 

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -157,14 +157,18 @@ function createElement(tag, attr) {
         children[_i - 2] = arguments[_i];
     }
     attr = attr || {};
+    var node;
     if (isString(tag)) {
-        var node = 'namespaceURI' in attr ? document.createElementNS(attr.namespaceURI, tag) : tag in svg ? document.createElementNS(SVGNamespace, tag) : document.createElement(tag);
+        node = 'namespaceURI' in attr ? document.createElementNS(attr.namespaceURI, tag) : tag in svg ? document.createElementNS(SVGNamespace, tag) : document.createElement(tag);
         attributes(attr, node);
         append(children, node);
-        return node;
     } else if (isFunction(tag)) {
-        return tag(__assign({}, attr, { children: children }));
+        node = tag(__assign({}, attr, { children: children }));
     }
+    if ("ref" in attr && isFunction(attr.ref)) {
+        attr.ref(node);
+    }
+    return node;
 }
 function append(children, node) {
     if (node === void 0) {
@@ -193,7 +197,6 @@ function attributes(attr, node) {
         var value = attr[key];
         switch (key) {
             case 'ref':
-                isFunction(value) && value(node);
                 continue;
             case 'style':
                 typeof value === 'object' ? __assign(node[key], value) : node.style = value;
@@ -239,5 +242,6 @@ function listen(node, eventName, callback) {
 exports.SVGNamespace = SVGNamespace;
 exports.preventDefault = preventDefault;
 exports.stopPropagation = stopPropagation;
+exports.className = className;
 exports.createElement = createElement;
 exports.DOM = DOM$$1;

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -192,6 +192,9 @@ function attributes(attr, node) {
         var key = _a[_i];
         var value = attr[key];
         switch (key) {
+            case 'ref':
+                isFunction(value) && value(node);
+                continue;
             case 'style':
                 typeof value === 'object' ? __assign(node[key], value) : node.style = value;
                 continue;

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -190,6 +190,9 @@ function attributes(attr, node) {
         var key = _a[_i];
         var value = attr[key];
         switch (key) {
+            case 'ref':
+                isFunction(value) && value(node);
+                continue;
             case 'style':
                 typeof value === 'object' ? __assign(node[key], value) : node.style = value;
                 continue;

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -155,14 +155,18 @@ function createElement(tag, attr) {
         children[_i - 2] = arguments[_i];
     }
     attr = attr || {};
+    var node;
     if (isString(tag)) {
-        var node = 'namespaceURI' in attr ? document.createElementNS(attr.namespaceURI, tag) : tag in svg ? document.createElementNS(SVGNamespace, tag) : document.createElement(tag);
+        node = 'namespaceURI' in attr ? document.createElementNS(attr.namespaceURI, tag) : tag in svg ? document.createElementNS(SVGNamespace, tag) : document.createElement(tag);
         attributes(attr, node);
         append(children, node);
-        return node;
     } else if (isFunction(tag)) {
-        return tag(__assign({}, attr, { children: children }));
+        node = tag(__assign({}, attr, { children: children }));
     }
+    if ("ref" in attr && isFunction(attr.ref)) {
+        attr.ref(node);
+    }
+    return node;
 }
 function append(children, node) {
     if (node === void 0) {
@@ -191,7 +195,6 @@ function attributes(attr, node) {
         var value = attr[key];
         switch (key) {
             case 'ref':
-                isFunction(value) && value(node);
                 continue;
             case 'style':
                 typeof value === 'object' ? __assign(node[key], value) : node.style = value;
@@ -234,4 +237,4 @@ function listen(node, eventName, callback) {
     return node;
 }
 
-export { SVGNamespace, preventDefault, stopPropagation, createElement, DOM$$1 as DOM };
+export { SVGNamespace, preventDefault, stopPropagation, className, createElement, DOM$$1 as DOM };

--- a/dist/jsx-dom.d.ts
+++ b/dist/jsx-dom.d.ts
@@ -7,6 +7,13 @@ type NativeElement = HTMLElement | SVGElement;
 type Dictionary<T> = {
   [key: string]: T;
 }
+type Ref<T> = ((instance: T) => any);
+
+declare module JSX {
+  interface IntrinsicAttributes {
+    ref?: Ref<Element>;
+  }
+}
 
 declare module "jsx-dom" {
   export function createElement<Tag extends keyof HTMLElementTagNameMap>(
@@ -23,7 +30,7 @@ declare module "jsx-dom" {
 
   export function createElement<Result extends Element, Props>(
     factory: (props: Props & { children: JSX.Child[] }) => Result,
-    props?: Props & { children?: any },
+    props?: Props & { ref?: Ref<Result>; children?: any },
     ...children: JSX.Child[]
   ): Result;
 
@@ -1834,6 +1841,7 @@ declare namespace JSX {
     innerText?: string;
     textContent?: string;
     namespaceURI?: string;
+    ref?: (e: Element) => void;
 
     // Clipboard Events
     onCopy?: ClipboardEventHandler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-dom",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "JSX to document.createElement.",
   "main": "dist/index.cjs.js",
   "jsnext:main": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-dom",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "JSX to document.createElement.",
   "main": "dist/index.cjs.js",
   "jsnext:main": "dist/index.es.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,9 @@ function attributes( attr, node ) {
     let value = attr[key];
 
     switch (key) {
+      case 'ref':
+        isFunction(value) && value(node);
+        continue;
       case 'style':
         typeof value === 'object'
         ? __assign( node[key], value )

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function isVisibleChild( value: any ) {
  * Convert a `value` to a className string.
  * `value` can be a string, an array or a `Dictionary<boolean>`.
  */
-function className( value: any ): string {
+export function className( value: string | (string | boolean)[] | { [className: string]: boolean} ): string {
   if (Array.isArray( value )) {
     return value.filter( isVisibleChild ).join(' ');
   } else if (isObject( value )) {
@@ -105,18 +105,22 @@ const svg = __assign(Object.create(null), {
 
 export function createElement( tag, attr, ...children ) {
   attr = attr || {};
+  let node: Element;
   if (isString( tag )) {
-    const node =
+     node =
       'namespaceURI' in attr ? document.createElementNS( attr.namespaceURI, tag )
       : tag in svg ? document.createElementNS( SVGNamespace, tag )
       : document.createElement( tag );
     attributes( attr, node );
     append( children, node );
-    return node;
   } else if (isFunction( tag )) {
     // Custom elements.
-    return tag({ ...attr, children });
+    node = tag({ ...attr, children });
   }
+  if("ref" in attr && isFunction(attr.ref)) {
+    attr.ref(node);
+  }
+  return node;
 }
 
 function append( children, node = this ) {
@@ -143,7 +147,6 @@ function attributes( attr, node ) {
 
     switch (key) {
       case 'ref':
-        isFunction(value) && value(node);
         continue;
       case 'style':
         typeof value === 'object'

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -93,6 +93,13 @@ describe('jsx-dom', function () {
 		button.click();
 	});
 
+	it('supports ref store function', function () {
+		let button = null;
+		const div = <div><button ref={e=>button=e}/></div> as HTMLButtonElement;
+		expect(button).not.to.equal(null);
+		expect(div.children[0]).to.equal(button);
+	});
+
 	describe('SVG', function () {
 		const namespace = jsx.SVGNamespace;
 

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -95,7 +95,15 @@ describe('jsx-dom', function () {
 
 	it('supports ref store function', function () {
 		let button = null;
-		const div = <div><button ref={e=>button=e}/></div> as HTMLButtonElement;
+		const div = <div><button ref={ e => button=e }/></div>;
+		expect(button).not.to.equal(null);
+		expect(div.children[0]).to.equal(button);
+	});
+	
+	it('supports ref in functional components', function () {
+		let button = null;
+		const Button = () => <button/>;
+		const div = <div><Button ref={ e => button=e }/></div>;
 		expect(button).not.to.equal(null);
 		expect(div.children[0]).to.equal(button);
 	});


### PR DESCRIPTION
Hey,
Very nice library - thanks!!

The ref provides an idiomatic way to store deep down Elements for future use - exactly as in React. Only function "ref" is supported as there is no natural place to store named refs and it is (nearly) deprecated anyway.
